### PR TITLE
remove double quotes

### DIFF
--- a/import-map-to-aws/entrypoint.sh
+++ b/import-map-to-aws/entrypoint.sh
@@ -143,7 +143,7 @@ deploy_import_map() {
 
   # Upload import-map to history folder
   echo "Upload import-map to history folder"
-  aws "$dryrun" s3 cp deploy-import-map.json "$s3_base/$history_folder/$(date "+%Y.%m.%d-%H.%M.%S").$FILE_NAME" --profile "$aws_profile"
+  aws s3 cp deploy-import-map.json "$s3_base/$history_folder/$(date "+%Y.%m.%d-%H.%M.%S").$FILE_NAME" --profile "$aws_profile" $dryrun
 
   # does import-map exist in s3?
   local -r -i file_exist="$(aws s3 ls "$aws_s3_bucket_import_map_url" --recursive --summarize --profile "$aws_profile" | grep 'Total Objects: ' | sed 's/[^0-9]*//g')"
@@ -156,7 +156,7 @@ deploy_import_map() {
   if [[ "$locked" == "\"true\"" ]]; then
     echo "$aws_s3_bucket_import_map_url is locked - new version of import-map could not be applied."
   else
-    aws "$dryrun" s3 cp deploy-import-map.json "$aws_s3_bucket_import_map_url" --cache-control "$CACHE_CONTROL" --profile "$aws_profile"
+    aws s3 cp deploy-import-map.json "$aws_s3_bucket_import_map_url" --cache-control "$CACHE_CONTROL" --profile "$aws_profile" $dryrun
     if [ -n "$AWS_DISTRIBUTION_ID" ]; then
       # invalidate S3 object to fetch origin from S3 bucket
       command="aws cloudfront create-invalidation --distribution-id $AWS_DISTRIBUTION_ID --paths $invalidation_path --profile $aws_profile"


### PR DESCRIPTION
Upload command was invalid once `dryrun` was false (set to empty string). Works once removing the double quotes.

Tested both `dryrun` and `no-dry-run`.