### PR TITLE
fix(qmfe-to-aws): fail when SOURCE is empty

### DIFF
--- a/qmfe-to-aws/entrypoint.sh
+++ b/qmfe-to-aws/entrypoint.sh
@@ -69,6 +69,13 @@ echo ""
 run() {
   [ ! -d "$SOURCE" ] && echo "ERROR: Directory $SOURCE does not exists." && exit 1
 
+  if [ "$(ls -A $SOURCE)" ]; then
+    echo "Preparing to upload files in $SOURCE"
+  else
+    echo "Directory '$SOURCE' is empty. Ensure the path is correct and that the project is built prior to running this action."
+    exit 1
+  fi
+
   aws --version
 
   aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" --profile qcs-cdn


### PR DESCRIPTION
Closes https://github.com/qlik-oss/qmfe-actions/issues/22

```
~qlik/oss-qmfe-actions bgd/fail-empty !1                                                                                    
❯ ls dist 
~qlik/oss-qmfe-actions bgd/fail-empty !1                                                                                    
❯ if [ "$(ls -A $SOURCE)" ]; then
    echo "Preparing to upload files in $SOURCE"
  else
    echo "Directory '$SOURCE' is empty. Ensure the path is correct and that the project is is built prior to running this action."
    # exit 1
    echo "exit 1"
  fi
Directory './dist' is empty. Ensure the path is correct and that the project is is built prior to running this action.
exit 1
~qlik/oss-qmfe-actions bgd/fail-empty !1                                                                                    
❯ touch dist/test.txt
~qlik/oss-qmfe-actions bgd/fail-empty !1 ?1                                                                                 
❯ if [ "$(ls -A $SOURCE)" ]; then
    echo "Preparing to upload files in $SOURCE"
  else
    echo "Directory '$SOURCE' is empty. Ensure the path is correct and that the project is built prior to running this action."
    # exit 1
    echo "exit 1"
  fi
Preparing to upload files in ./dist
~qlik/oss-qmfe-actions bgd/fail-empty !1 ?1                                                                                 
❯ rm dist/test.txt
~qlik/oss-qmfe-actions bgd/fail-empty !1                                                                                    
❯ if [ "$(ls -A $SOURCE)" ]; then
    echo "Preparing to upload files in $SOURCE"
  else
    echo "Directory '$SOURCE' is empty. Ensure the path is correct and that the project is is built prior to running this action."
    # exit 1
    echo "exit 1"
  fi
Directory './dist' is empty. Ensure the path is correct and that the project is built prior to running this action.
exit 1
```