### PR TITLE
fix: do not fail script on CreateInvalidation failure

### DIFF
--- a/import-map-to-aws/import-map-to-aws.sh
+++ b/import-map-to-aws/import-map-to-aws.sh
@@ -177,10 +177,12 @@ else
       echo "(dryrun) $command"
       echo "(dryrun) curl $IMPORT_MAP_URL"
     else
+      set +e
       echo "invalidating import-map.json file at cloudfront"
       eval "$command"
       # curl the file to warm up the cache
       curl "$IMPORT_MAP_URL"
+      set -e
     fi
   fi
 fi


### PR DESCRIPTION
Fix to prevent script to fail in those cases where the `CreateInvalidation` operation are failing, since this result in misleading notifications about failing import-map deploys (even though the import-map itself was uploaded successfully).

![Screenshot 2022-05-05 at 11 39 04](https://user-images.githubusercontent.com/24582521/166899710-1e39de76-49d6-4bb5-8e6a-5e339cad50cd.png)

