### PR TITLE
fix: use env. file instead of set-output command

### DIFF
--- a/import-map-to-aws/import-map-to-aws.sh
+++ b/import-map-to-aws/import-map-to-aws.sh
@@ -187,4 +187,4 @@ else
   fi
 fi
 
-echo "::set-output name=import-map-locked-state::$locked"
+echo "import-map-locked-state=$locked" >> $GITHUB_OUTPUT


### PR DESCRIPTION
`set-output` command is being deprecated: 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/